### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "guzzlehttp/guzzle": "4.*",
-        "doctrine/cache": "~1.3.0"
+        "guzzlehttp/guzzle": "~4.0",
+        "doctrine/cache": "~1.3"
     },
     "autoload": {
         "psr-4": { "GuzzleHttp\\Subscriber\\Cache\\": "src" }


### PR DESCRIPTION
Improved version constraints. Is there any reason why we are being so restrictive on the doctrine/cache version?
