### PR TITLE
Fixed install guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,7 +88,7 @@ Add the following to your composer.json:
 
     {
         "require": {
-            "guzzlehttp/cache-subscriber": "0.1-dev"
+            "guzzlehttp/cache-subscriber": "0.1.*@dev"
         }
     }
 


### PR DESCRIPTION
The version constraint was wrong. You should avoid using branch names were possible.
