### PR TITLE
Fix Utils method

### DIFF
--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -145,6 +145,18 @@ class CacheStorage implements CacheStorageInterface
     }
 
     /**
+     * Set the cache key prefix
+     *
+     * @param string $name
+     *
+     * @return void
+     */
+    public function setPrefix($name)
+    {
+        $this->keyPrefix = $name;
+    }
+
+    /**
      * Hash a request URL into a string that returns cache metadata
      *
      * @param RequestInterface $request


### PR DESCRIPTION
This class is unusable with guzzle 5 as the methods do not exist without the Utils reference
