### PR TITLE
Add tests for expired items without must-revalidate.

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -39,7 +39,21 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
                 'Cache-Control' => 'private, s-maxage=0, max-age=0, must-revalidate',
                 'Last-Modified' => 'Wed, 29 Oct 2014 20:30:57 GMT',
                 'Age' => '1278'
-            ])
+            ]),
+            new Response(200, [
+              'Vary' => 'Accept-Encoding,Cookie,X-Use-HHVM',
+              'Date' => 'Wed, 29 Oct 2014 20:52:15 GMT',
+              'Cache-Control' => 'private, s-maxage=0, max-age=0',
+              'Last-Modified' => 'Wed, 29 Oct 2014 20:30:57 GMT',
+              'Age' => '1277'
+            ]),
+            new Response(200, [
+              'Vary' => 'Accept-Encoding,Cookie,X-Use-HHVM',
+              'Date' => 'Wed, 29 Oct 2014 20:53:15 GMT',
+              'Cache-Control' => 'private, s-maxage=0, max-age=0',
+              'Last-Modified' => 'Wed, 29 Oct 2014 20:53:00 GMT',
+              'Age' => '1277'
+            ]),
         ]);
 
         $client = new Client(['base_url' => Server::$url]);
@@ -50,9 +64,20 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response1->getStatusCode());
         $response2 = $client->get('/foo');
         $this->assertEquals(200, $response2->getStatusCode());
-        $this->assertCount(2, Server::received());
         $last = $history->getLastResponse();
         $this->assertEquals('HIT from GuzzleCache', $last->getHeader('X-Cache-Lookup'));
         $this->assertEquals('HIT from GuzzleCache', $last->getHeader('X-Cache'));
+
+        // Validate that expired requests without must-revalidate expire.
+        $response3 = $client->get('/foo');
+        $this->assertEquals(200, $response3->getStatusCode());
+        $response4 = $client->get('/foo');
+        $this->assertEquals(200, $response4->getStatusCode());
+        $last = $history->getLastResponse();
+        $this->assertEquals('MISS from GuzzleCache', $last->getHeader('X-Cache-Lookup'));
+        $this->assertEquals('MISS from GuzzleCache', $last->getHeader('X-Cache'));
+
+        // Validate that all of our requests were received.
+        $this->assertCount(4, Server::received());
     }
 }


### PR DESCRIPTION
This tests expiration for responses that have max-age set to zero but do not specify must-revalidate.
