### PR TITLE
Support Vary response headers in cache keys

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -6,18 +6,19 @@ require_once __DIR__ . '/../vendor/guzzlehttp/guzzle/tests/Server.php';
 
 use GuzzleHttp\Client;
 use GuzzleHttp\Message\Response;
+use GuzzleHttp\Stream\Stream;
 use GuzzleHttp\Subscriber\Cache\CacheSubscriber;
 use GuzzleHttp\Subscriber\History;
 use GuzzleHttp\Tests\Server;
 
 class IntegrationTest extends \PHPUnit_Framework_TestCase
 {
-    public static function setupBeforeClass()
+    protected function setUp()
     {
         Server::start();
     }
 
-    public static function tearDownAfterClass()
+    protected function tearDown()
     {
         Server::stop();
     }
@@ -42,10 +43,9 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             ])
         ]);
 
-        $client = new Client(['base_url' => Server::$url]);
-        CacheSubscriber::attach($client);
         $history = new History();
-        $client->getEmitter()->attach($history);
+        $client = $this->setupClient($history);
+
         $response1 = $client->get('/foo');
         $this->assertEquals(200, $response1->getStatusCode());
         $response2 = $client->get('/foo');
@@ -54,5 +54,338 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $last = $history->getLastResponse();
         $this->assertEquals('HIT from GuzzleCache', $last->getHeader('X-Cache-Lookup'));
         $this->assertEquals('HIT from GuzzleCache', $last->getHeader('X-Cache'));
+    }
+
+    /**
+     * Test that the Vary header creates unique cache entries.
+     *
+     * @throws \Exception
+     */
+    public function testVaryUniqueResponses()
+    {
+        $now = gmdate("D, d M Y H:i:s");
+
+        Server::enqueue(
+            [
+                new Response(
+                    200, [
+                    'Vary' => 'Accept',
+                    'Content-type' => 'text/html',
+                    'Date' => $now,
+                    'Cache-Control' => 'public, s-maxage=1000, max-age=1000',
+                    'Last-Modified' => $now,
+                ], Stream::factory('It works!')
+                ),
+                new Response(
+                    200, [
+                    'Vary' => 'Accept',
+                    'Content-type' => 'application/json',
+                    'Date' => $now,
+                    'Cache-Control' => 'public, s-maxage=1000, max-age=1000',
+                    'Last-Modified' => $now,
+                ], Stream::factory(json_encode(['body' => 'It works!']))
+                ),
+            ]
+        );
+
+        $client = $this->setupClient();
+
+        $response1 = $client->get(
+            '/foo',
+            ['headers' => ['Accept' => 'text/html']]
+        );
+        $this->assertEquals('It works!', $this->getResponseBody($response1));
+
+        $response2 = $client->get(
+            '/foo',
+            ['headers' => ['Accept' => 'application/json']]
+        );
+        $this->assertEquals(
+            'MISS from GuzzleCache',
+            $response2->getHeader('x-cache')
+        );
+
+        $decoded = json_decode($this->getResponseBody($response2));
+
+        if (!isset($decoded) || !isset($decoded->body)) {
+            $this->fail('JSON response could not be decoded.');
+        } else {
+            $this->assertEquals('It works!', $decoded->body);
+        }
+    }
+
+    /**
+     * Test that requests varying on both Accept and User-Agent properly split
+     * different User-Agents into different cache items.
+     */
+    public function testVaryUserAgent()
+    {
+        $this->setupMultipleVaryResponses();
+        $client = $this->setupClient();
+
+        $response1 = $client->get(
+            '/foo',
+            [
+                'headers' => [
+                    'Accept' => 'text/html',
+                    'User-Agent' => 'Testing/1.0'
+                ]
+            ]
+        );
+        $this->assertEquals(
+            'Test/1.0 request.',
+            $this->getResponseBody($response1)
+        );
+
+        $response2 = $client->get(
+            '/foo',
+            [
+                'headers' => [
+                    'Accept' => 'text/html',
+                    'User-Agent' => 'Testing/2.0'
+                ]
+            ]
+        );
+        $this->assertEquals(
+            'MISS from GuzzleCache',
+            $response2->getHeader('x-cache')
+        );
+        $this->assertEquals(
+            'Test/2.0 request.',
+            $this->getResponseBody($response2)
+        );
+
+        // Test that we get cache hits where both Vary headers match.
+        $response5 = $client->get(
+            '/foo',
+            [
+                'headers' => [
+                    'Accept' => 'text/html',
+                    'User-Agent' => 'Testing/2.0'
+                ]
+            ]
+        );
+        $this->assertEquals(
+            'HIT from GuzzleCache',
+            $response5->getHeader('x-cache')
+        );
+        $this->assertEquals(
+            'Test/2.0 request.',
+            $this->getResponseBody($response5)
+        );
+
+    }
+
+    /**
+     * Test that requests varying on Accept but not User-Agent return different responses.
+     */
+    public function testVaryAccept()
+    {
+        $this->setupMultipleVaryResponses();
+        $client = $this->setupClient();
+
+        // Prime the cache.
+        $client->get(
+            '/foo',
+            [
+                'headers' => [
+                    'Accept' => 'text/html',
+                    'User-Agent' => 'Testing/1.0'
+                ]
+            ]
+        );
+        $client->get(
+            '/foo',
+            [
+                'headers' => [
+                    'Accept' => 'text/html',
+                    'User-Agent' => 'Testing/2.0'
+                ]
+            ]
+        );
+
+        $response1 = $client->get(
+            '/foo',
+            [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'Testing/1.0'
+                ]
+            ]
+        );
+        $this->assertEquals(
+            'MISS from GuzzleCache',
+            $response1->getHeader('x-cache')
+        );
+        $this->assertEquals(
+            'Test/1.0 request.',
+            json_decode($this->getResponseBody($response1))->body
+        );
+
+        $response2 = $client->get(
+            '/foo',
+            [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'Testing/2.0'
+                ]
+            ]
+        );
+        $this->assertEquals(
+            'MISS from GuzzleCache',
+            $response2->getHeader('x-cache')
+        );
+        $this->assertEquals(
+            'Test/2.0 request.',
+            json_decode($this->getResponseBody($response2))->body
+        );
+    }
+
+    /**
+     * Test that we return cached responses when multiple Vary headers match.
+     */
+    public function testMultipleVaryMatch()
+    {
+        $this->setupMultipleVaryResponses();
+        $client = $this->setupClient();
+
+        // Prime the cache.
+        $client->get('/foo',
+            [
+                'headers' => [
+                    'Accept' => 'text/html',
+                    'User-Agent' => 'Testing/1.0'
+                ]
+            ]
+        );
+        $client->get('/foo',
+            [
+                'headers' => [
+                    'Accept' => 'text/html',
+                    'User-Agent' => 'Testing/2.0'
+                ]
+            ]
+        );
+        $client->get('/foo',
+            [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'Testing/1.0'
+                ]
+            ]
+        );
+        $client->get('/foo',
+            [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'Testing/2.0'
+                ]
+            ]
+        );
+
+        $response = $client->get(
+            '/foo',
+            [
+                'headers' => [
+                    'Accept' => 'application/json',
+                    'User-Agent' => 'Testing/2.0'
+                ]
+            ]
+        );
+        $this->assertEquals(
+            'HIT from GuzzleCache',
+            $response->getHeader('x-cache')
+        );
+        $this->assertEquals(
+            'Test/2.0 request.',
+            json_decode($this->getResponseBody($response))->body
+        );
+    }
+
+    /**
+     * Decode a response body from TestServer.
+     *
+     * TestServer encodes all responses with base64, so we need to decode them
+     * before we can do any assert's on them.
+     *
+     * @param Response $response The response with a body to decode.
+     *
+     * @return string
+     */
+    private function getResponseBody($response)
+    {
+        return base64_decode($response->getBody());
+    }
+
+    /**
+     * Set up responses used by our Vary tests.
+     *
+     * @throws \Exception
+     */
+    private function setupMultipleVaryResponses()
+    {
+        $now = gmdate("D, d M Y H:i:s");
+
+        Server::enqueue(
+            [
+                new Response(
+                    200, [
+                    'Vary' => 'Accept, User-Agent',
+                    'Content-type' => 'text/html',
+                    'Date' => $now,
+                    'Cache-Control' => 'public, s-maxage=1000, max-age=1000',
+                    'Last-Modified' => $now,
+                ], Stream::factory('Test/1.0 request.')
+                ),
+                new Response(
+                    200,
+                    [
+                        'Vary' => 'Accept, User-Agent',
+                        'Content-type' => 'text/html',
+                        'Date' => $now,
+                        'Cache-Control' => 'public, s-maxage=1000, max-age=1000',
+                        'Last-Modified' => $now,
+                    ],
+                    Stream::factory('Test/2.0 request.')
+                ),
+                new Response(
+                    200, [
+                    'Vary' => 'Accept, User-Agent',
+                    'Content-type' => 'application/json',
+                    'Date' => $now,
+                    'Cache-Control' => 'public, s-maxage=1000, max-age=1000',
+                    'Last-Modified' => $now,
+                ], Stream::factory(json_encode(['body' => 'Test/1.0 request.']))
+                ),
+                new Response(
+                    200, [
+                    'Vary' => 'Accept, User-Agent',
+                    'Content-type' => 'application/json',
+                    'Date' => $now,
+                    'Cache-Control' => 'public, s-maxage=1000, max-age=1000',
+                    'Last-Modified' => $now,
+                ], Stream::factory(json_encode(['body' => 'Test/2.0 request.']))
+                ),
+            ]
+        );
+    }
+
+    /**
+     * Setup a Guzzle client for testing.
+     *
+     * @param History $history (optional) parameter of a History to track
+     *                         requests in.
+     *
+     * @return Client A client ready to run test requests against.
+     */
+    private function setupClient(History $history = null)
+    {
+        $client = new Client(['base_url' => Server::$url]);
+        CacheSubscriber::attach($client);
+        if ($history) {
+            $client->getEmitter()->attach($history);
+        }
+
+        return $client;
     }
 }


### PR DESCRIPTION
This PR fixes Responses with different Vary headers being combined within the same cache items. This is especially important for content type or language negotiation, where different request headers may cause different responses to be returned for the same method and URL.
