### PR TITLE
Fix not adding timezone to dates.

### DIFF
--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -88,7 +88,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
      */
     public function testVaryUniqueResponses()
     {
-        $now = gmdate("D, d M Y H:i:s");
+        $now = $this->date();
 
         Server::enqueue(
             [
@@ -349,7 +349,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
      */
     private function setupMultipleVaryResponses()
     {
-        $now = gmdate("D, d M Y H:i:s");
+        $now = $this->date();
 
         Server::enqueue(
             [
@@ -412,5 +412,21 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         }
 
         return $client;
+    }
+
+    /**
+     * Return a date string suitable for using in an HTTP header.
+     *
+     * @param int $timestamp (optional) A Unix timestamp to generate the date.
+     *
+     * @return string The generated date string.
+     */
+    private function date($timestamp = null)
+    {
+        if (!$timestamp) {
+            $timestamp = time();
+        }
+
+        return gmdate("D, d M Y H:i:s", $timestamp) . ' GMT';
     }
 }


### PR DESCRIPTION
Dates generated as "now" were being returned without 'GMT'. Amazingly, this didn't cause any existing tests to fail, but it's causing work I'm doing on stale-if-error to break pretty badly.
