### PR TITLE
Issue #22: Add setDefaultTtl() to CacheStorage.

### DIFF
--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -26,13 +26,15 @@ class CacheStorage implements CacheStorageInterface
     private $cache;
 
     /**
-     * @param Cache  $cache     Cache backend.
-     * @param string $keyPrefix Key prefix to add to each key.
+     * @param Cache  $cache      Cache backend.
+     * @param string $keyPrefix  (optional) Key prefix to add to each key.
+     * @param int    $defaultTtl (optional) The default TTL to set, in seconds.
      */
-    public function __construct(Cache $cache, $keyPrefix = null)
+    public function __construct(Cache $cache, $keyPrefix = null, $defaultTtl = 0)
     {
         $this->cache = $cache;
         $this->keyPrefix = $keyPrefix;
+        $this->defaultTtl = $defaultTtl;
     }
 
     public function cache(

--- a/tests/CacheStorageTest.php
+++ b/tests/CacheStorageTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace GuzzleHttp\Tests\Subscriber\Cache;
+
+use Doctrine\Common\Cache\ArrayCache;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Subscriber\Cache\CacheStorage;
+
+/**
+ * Test the CacheStorage class.
+ *
+ * @class CacheStorageTest
+ */
+class CacheStorageTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * Test that a Response's max-age returns the correct TTL.
+     */
+    public function testGetTtlMaxAge()
+    {
+        $response = new Response(200, [
+            'Cache-control' => 'max-age=10',
+        ]);
+
+        $getTtl = $this->getMethod('getTtl');
+        $cache = new CacheStorage(new ArrayCache());
+        $ttl = $getTtl->invokeArgs($cache, array($response));
+        $this->assertEquals(10, $ttl);
+    }
+
+    /**
+     * Test that the default TTL for cachable responses with no max-age headers
+     * is zero.
+     */
+    public function testGetTtlDefault()
+    {
+        $response = new Response(200);
+
+        $getTtl = $this->getMethod('getTtl');
+        $cache = new CacheStorage(new ArrayCache());
+        $ttl = $getTtl->invokeArgs($cache, array($response));
+
+        // assertSame() here to be specific about null / false returns.
+        $this->assertSame(0, $ttl);
+    }
+
+    /**
+     * Test setting the default TTL.
+     */
+    public function testSetTtlDefault()
+    {
+        $response = new Response(200);
+
+        $getTtl = $this->getMethod('getTtl');
+        $cache = new CacheStorage(new ArrayCache(), null, 10);
+        $ttl = $getTtl->invokeArgs($cache, array($response));
+        $this->assertEquals(10, $ttl);
+    }
+
+    /**
+     * Return a protected or private method.
+     *
+     * @param string $name The name of the method.
+     *
+     * @return \ReflectionMethod A method object.
+     */
+    protected static function getMethod($name)
+    {
+        $class = new \ReflectionClass('GuzzleHttp\Subscriber\Cache\CacheStorage');
+        $method = $class->getMethod($name);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+}


### PR DESCRIPTION
This also adds tests for getTtl(). It's not complete in that there's no test for stale-if-header, but that's broken so I'll file that in a different PR with a fix.
