### PR TITLE
Fix stale-if-header not being added to max-age.

### DIFF
--- a/tests/CacheStorageTest.php
+++ b/tests/CacheStorageTest.php
@@ -59,6 +59,35 @@ class CacheStorageTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test that stale-if-error is added to the max-age header.
+     */
+    public function testGetTtlMaxAgeStaleIfError()
+    {
+        $response = new Response(200, [
+            'Cache-control' => 'max-age=10, stale-if-error=10',
+        ]);
+
+        $getTtl = $this->getMethod('getTtl');
+        $cache = new CacheStorage(new ArrayCache());
+        $ttl = $getTtl->invokeArgs($cache, array($response));
+        $this->assertEquals(20, $ttl);
+    }
+
+    /**
+     * Test that stale-if-error works without a max-age header.
+     */
+    public function testGetTtlStaleIfErrorAlone()
+    {
+        $response = new Response(200, [
+            'Cache-control' => 'stale-if-error=10',
+        ]);
+
+        $getTtl = $this->getMethod('getTtl');
+        $cache = new CacheStorage(new ArrayCache());
+        $ttl = $getTtl->invokeArgs($cache, array($response));
+        $this->assertEquals(10, $ttl);
+    }
+    /**
      * Return a protected or private method.
      *
      * @param string $name The name of the method.


### PR DESCRIPTION
Depends on #25.

This fixes stale-if-header being skipped due to a backwards conditional. However, I was also running into issues with false or null being conflated with zeros, so I added is_numeric() checks before modifying $ttl.
