### PR TITLE
Adds tests for stale-if-error behaviour.

### DIFF
--- a/src/CacheSubscriber.php
+++ b/src/CacheSubscriber.php
@@ -183,7 +183,6 @@ class CacheSubscriber implements SubscriberInterface
         if ($response && $this->validateFailed($request, $response)) {
             $request->getConfig()->set('cache_hit', 'error');
             $response->setHeader('Age', Utils::getResponseAge($response));
-            $this->addResponseHeaders($request, $response);
             $event->intercept($response);
         }
     }


### PR DESCRIPTION
This also fixes:
- Adding duplicate headers on stale responses that are handled in
  onComplete.
- Overwriting an event variable with an exception.
- can_cache test assuming can_cache works in error conditions.
