### PR TITLE
Bumped branch alias to 0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1-dev"
+            "dev-master": "0.2-dev"
         }
     }
 }


### PR DESCRIPTION
There have been some significant improvements since 0.1, and probably a few more to come too, so I propose we bump the branch alias to 0.2-dev in preparation for the next tag being 0.2.0.
