### PR TITLE
request cache.ttl option and response X-Cache-Ttl header

### DIFF
--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -57,7 +57,7 @@ class CacheStorage implements CacheStorageInterface
         ResponseInterface $response
     ) {
         $ctime = time();
-        $ttl = $this->getTtl($response);
+        $ttl = $this->getTtl($request, $response);
         $key = $this->getCacheKey($request, $this->normalizeVary($response));
         $headers = $this->persistHeaders($request);
         $entries = $this->getManifestEntries($key, $ctime, $response, $headers);
@@ -80,8 +80,11 @@ class CacheStorage implements CacheStorageInterface
             $this->persistHeaders($response),
             $response->getStatusCode(),
             $bodyDigest,
-            $ctime + $ttl
+            $ctime + $ttl,
+            $ttl
         ]);
+
+        $request->getConfig()->set('cache.used_ttl', $ttl);
 
         $this->cache->save($key, serialize($entries));
     }
@@ -176,6 +179,10 @@ class CacheStorage implements CacheStorageInterface
             return null;
         }
 
+        if (isset($match[5])) {
+            $request->getConfig()->set('cache.used_ttl', $match[5]);
+        }
+
         return $response;
     }
 
@@ -267,7 +274,7 @@ class CacheStorage implements CacheStorageInterface
      *
      * @return int The TTL in seconds.
      */
-    private function getTtl(ResponseInterface $response)
+    private function getTtl(RequestInterface $request, ResponseInterface $response)
     {
         $ttl = 0;
 
@@ -283,6 +290,10 @@ class CacheStorage implements CacheStorageInterface
             if (is_numeric($stale)) {
                 $ttl += $stale;
             }
+        }
+
+        if (($forceTtl = $request->getConfig()->get('cache.ttl')) !== null) {
+            $ttl = (int) $forceTtl;
         }
 
         return $ttl ?: $this->defaultTtl;
@@ -352,7 +363,7 @@ class CacheStorage implements CacheStorageInterface
         ResponseInterface $response
     ) {
         $key = $this->getVaryKey($request);
-        $this->cache->save($key, $this->normalizeVary($response), $this->getTtl($response));
+        $this->cache->save($key, $this->normalizeVary($response), $this->getTtl($request, $response));
     }
 
     /**

--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -270,6 +270,7 @@ class CacheStorage implements CacheStorageInterface
     /**
      * Return the TTL to use when caching a Response.
      *
+     * @param RequestInterface $request The response calling request
      * @param ResponseInterface $response The response being cached.
      *
      * @return int The TTL in seconds.

--- a/src/CacheSubscriber.php
+++ b/src/CacheSubscriber.php
@@ -256,6 +256,10 @@ class CacheSubscriber implements SubscriberInterface
             $response->addHeader('X-Cache', 'MISS from GuzzleCache');
         }
 
+        if (isset($params['cache.used_ttl'])) {
+            $response->addHeader('X-Cache-Ttl', $params['cache.used_ttl']);
+        }
+
         $freshness = Utils::getFreshness($response);
 
         // Only add a Warning header if we are returning a stale response.

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -70,6 +70,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $last = $history->getLastResponse();
         $this->assertEquals('HIT from GuzzleCache', $last->getHeader('X-Cache-Lookup'));
         $this->assertEquals('HIT from GuzzleCache', $last->getHeader('X-Cache'));
+        $this->assertEquals(0, $last->getHeader('X-Cache-Ttl'));
 
         // Validate that expired requests without must-revalidate expire.
         $response3 = $client->get('/foo');
@@ -79,6 +80,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $last = $history->getLastResponse();
         $this->assertEquals('MISS from GuzzleCache', $last->getHeader('X-Cache-Lookup'));
         $this->assertEquals('MISS from GuzzleCache', $last->getHeader('X-Cache'));
+        $this->assertEquals(0, $last->getHeader('X-Cache-Ttl'));
 
         // Validate that all of our requests were received.
         $this->assertCount(4, Server::received());
@@ -143,6 +145,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             ['headers' => ['Accept' => 'text/html']]
         );
         $this->assertEquals('It works!', $this->getResponseBody($response1));
+        $this->assertEquals(1000, $response1->getHeader('X-Cache-Ttl'));
 
         $response2 = $client->get(
             '/foo',
@@ -152,6 +155,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             'MISS from GuzzleCache',
             $response2->getHeader('x-cache')
         );
+        $this->assertEquals(1000, $response2->getHeader('X-Cache-Ttl'));
 
         $decoded = json_decode($this->getResponseBody($response2));
 
@@ -194,6 +198,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
         $response2 = $client->get('/foo');
         $this->assertEquals(200, $response2->getStatusCode());
         $this->assertEquals('HIT from GuzzleCache', $response2->getHeader('X-Cache'));
+        $this->assertEquals(1000, $response2->getHeader('X-Cache-Ttl'));
     }
 
     /**
@@ -377,6 +382,7 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
             'HIT from GuzzleCache',
             $response->getHeader('x-cache')
         );
+        $this->assertEquals(1000, $response->getHeader('X-Cache-Ttl'));
         $this->assertEquals(
             'Test/2.0 request.',
             json_decode($this->getResponseBody($response))->body
@@ -493,8 +499,11 @@ class IntegrationTest extends \PHPUnit_Framework_TestCase
 
         $response1 = $client->get('/foo');
         $this->assertEquals('MISS from GuzzleCache', $response1->getHeader('X-Cache-Lookup'));
+        $this->assertEquals(0, $response1->getHeader('X-Cache-Ttl'));
+
         $response2 = $client->get('/foo');
         $this->assertEquals('HIT from GuzzleCache', $response2->getHeader('X-Cache-Lookup'));
+        $this->assertEquals(0, $response2->getHeader('X-Cache-Ttl'));
         $this->assertEquals('It works!', $this->getResponseBody($response2));
     }
 


### PR DESCRIPTION
add request cache.ttl option to overidde reponse max-age and set a response header `X-Cache-Ttl` with cache storage TTL (useful for some plugins like [CsaGuzzleBundle](https://github.com/csarrazi/CsaGuzzleBundle) to display cache TTL in debug )