### PR TITLE
extend caching ttl considerations

### DIFF
--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -283,6 +283,8 @@ class CacheStorage implements CacheStorageInterface
             if (is_numeric($stale)) {
                 $ttl += $stale;
             }
+        } elseif ($expires = $response->getHeader('Expires')) {
+            $ttl += strtotime($expires) - time();
         }
 
         return $ttl ?: $this->defaultTtl;

--- a/tests/CacheStorageTest.php
+++ b/tests/CacheStorageTest.php
@@ -86,6 +86,40 @@ class CacheStorageTest extends \PHPUnit_Framework_TestCase
         $ttl = $getTtl->invokeArgs($cache, [$response]);
         $this->assertEquals(10, $ttl);
     }
+
+    /**
+     * Test that expires is considered when cache-control is not available.
+     */
+    public function testGetTtlExpires()
+    {
+        $expires = new \DateTime('+100 seconds');
+        $response = new Response(200, [
+            'Expires' => $expires->format(DATE_RFC1123),
+        ]);
+
+        $getTtl = $this->getMethod('getTtl');
+        $cache = new CacheStorage(new ArrayCache());
+        $ttl = $getTtl->invokeArgs($cache, [$response]);
+        $this->assertEquals(100, $ttl);
+    }
+
+    /**
+     * Test that cache-control is considered before expires.
+     */
+    public function testGetTtlCacheControlExpires()
+    {
+        $expires = new \DateTime('+100 seconds');
+        $response = new Response(200, [
+            'Expires' => $expires->format(DATE_RFC1123),
+            'Cache-control' => 'max-age=10',
+        ]);
+
+        $getTtl = $this->getMethod('getTtl');
+        $cache = new CacheStorage(new ArrayCache());
+        $ttl = $getTtl->invokeArgs($cache, [$response]);
+        $this->assertEquals(10, $ttl);
+    }
+
     /**
      * Return a protected or private method.
      *


### PR DESCRIPTION
Cache-Control is not the only header that can determine how long a
response is considered valid. Expires is old but still widely in use. If
Cache-Control is not present, Expires should be considered next (if
available) to determine a ttl.

I purposely did not use Utils::getMaxAge() since it does not take into
account max-stale and I was not sure if that function should be modified
or not (with concerns to backwards compatibility etc).

Any feedback?

Refs #55 