### PR TITLE
Add purge method

### DIFF
--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -111,7 +111,7 @@ class CacheStorage implements CacheStorageInterface
 
     public function purge($url)
     {
-        foreach (['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS'] as $m) {
+        foreach (['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PURGE'] as $m) {
             $this->delete(new Request($m, $url));
         }
     }

--- a/src/PurgeSubscriber.php
+++ b/src/PurgeSubscriber.php
@@ -4,6 +4,7 @@ namespace GuzzleHttp\Subscriber\Cache;
 use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Event\RequestEvents;
 use GuzzleHttp\Event\SubscriberInterface;
+use GuzzleHttp\Message\Response;
 
 /**
  * Automatically purges a URL when a non-idempotent request is made to it.
@@ -19,6 +20,7 @@ class PurgeSubscriber implements SubscriberInterface
         'POST'   => true,
         'DELETE' => true,
         'PATCH'  => true,
+        'PURGE'  => true,
     ];
 
     /**
@@ -40,6 +42,10 @@ class PurgeSubscriber implements SubscriberInterface
 
         if (isset(self::$purgeMethods[$request->getMethod()])) {
             $this->storage->purge($request->getUrl());
+
+            if ('PURGE' === $request->getMethod()) {
+                $event->intercept(new Response(204));
+            }
         }
     }
 }

--- a/src/PurgeSubscriber.php
+++ b/src/PurgeSubscriber.php
@@ -39,7 +39,7 @@ class PurgeSubscriber implements SubscriberInterface
         $request = $event->getRequest();
 
         if (isset(self::$purgeMethods[$request->getMethod()])) {
-            $this->storage->purge($request);
+            $this->storage->purge($request->getUrl());
         }
     }
 }


### PR DESCRIPTION
I didn't add any conditional checks. It seems relatively safe to just respond with a 204 regardless of whether a cached response was purged from the cache or not (in which cache it was never cached anyway).

I also spotted a little bug I think. CacheStorage::purge() accepts a url, but the handler in PurgeSubscriber
actually passed the complete request instance. Changed it to $request->getUrl() instead.

Refs #54 