### PR TITLE
Allow 308 and 206 responses to be cached

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -116,11 +116,6 @@ class Utils
             return false;
         }
 
-        // Don't fool with Range requests for now
-        if ($request->hasHeader('Range')) {
-            return false;
-        }
-
         return self::getDirective($request, 'no-store') === null;
     }
 
@@ -133,7 +128,7 @@ class Utils
      */
     public static function canCacheResponse(ResponseInterface $response)
     {
-        static $cacheCodes = [200, 203, 300, 301, 308, 410];
+        static $cacheCodes = [200, 203, 206, 300, 301, 308, 410];
 
         // Check if the response is cacheable based on the code
         if (!in_array((int) $response->getStatusCode(), $cacheCodes)) {
@@ -152,8 +147,8 @@ class Utils
             return false;
         }
 
-        // Don't fool with Content-Range requests for now
-        if ($response->hasHeader('Content-Range')) {
+        // Range responses should be 206 Partial Content
+        if ($response->getStatusCode() !== 206 && $response->hasHeader('Content-Range')) {
             return false;
         }
 

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -128,7 +128,7 @@ class Utils
      */
     public static function canCacheResponse(ResponseInterface $response)
     {
-        static $cacheCodes = [200, 203, 206, 300, 301, 308, 410];
+        static $cacheCodes = [200, 203, 206, 300, 301, 308, 404, 410];
 
         // Check if the response is cacheable based on the code
         if (!in_array((int) $response->getStatusCode(), $cacheCodes)) {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -146,12 +146,7 @@ class Utils
         if (self::getDirective($response, 'no-store')) {
             return false;
         }
-
-        // Range responses should be 206 Partial Content
-        if ($response->getStatusCode() !== 206 && $response->hasHeader('Content-Range')) {
-            return false;
-        }
-
+        
         $freshness = self::getFreshness($response);
 
         return $freshness === null                    // No freshness info.

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -133,7 +133,7 @@ class Utils
      */
     public static function canCacheResponse(ResponseInterface $response)
     {
-        static $cacheCodes = [200, 203, 300, 301, 410];
+        static $cacheCodes = [200, 203, 300, 301, 308, 410];
 
         // Check if the response is cacheable based on the code
         if (!in_array((int) $response->getStatusCode(), $cacheCodes)) {

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -81,7 +81,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase
         return [
             [true,  200, []],
             [false, 200, ['Cache-Control' => 'no-store']],
-            [false, 200, ['Content-Range' => '0-5']],
+            [true,  200, ['Content-Range' => '0-5']],
             [true,  206, ['Content-Range' => '0-5']],
             [true,  203, []],
             [true,  300, []],

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -62,4 +62,32 @@ class UtilsTest extends PHPUnit_Framework_TestCase
         $response = $messageFactory->createResponse(200);
         $this->assertSame(null, Utils::getFreshness($response));
     }
+
+    /**
+     * Test that responses are cache-able
+     * @dataProvider exampleResponses
+     */
+    public function testCanCacheResponse($canCache, $statusCode, $headers)
+    {
+        $messageFactory = new MessageFactory();
+        $response = $messageFactory->createResponse($statusCode);
+        $response->setHeaders($headers);
+        $this->assertSame($canCache, Utils::canCacheResponse($response));
+    }
+
+    public function exampleResponses()
+    {
+        return [
+            [true,  200, []],
+            [false, 200, ['Cache-Control' => 'no-store']],
+            [false, 200, ['Content-Range' => '0-5']],
+            [true,  203, []],
+            [true,  300, []],
+            [true,  301, []],
+            [true,  308, []],
+            [true,  410, []],
+            [false, 500, []],
+            [false, 201, []],
+        ];
+    }
 }

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -87,6 +87,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase
             [true,  300, []],
             [true,  301, []],
             [true,  308, []],
+            [true,  404, []],
             [true,  410, []],
             [false, 500, []],
             [false, 201, []],

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -82,6 +82,7 @@ class UtilsTest extends PHPUnit_Framework_TestCase
             [true,  200, []],
             [false, 200, ['Cache-Control' => 'no-store']],
             [false, 200, ['Content-Range' => '0-5']],
+            [true,  206, ['Content-Range' => '0-5']],
             [true,  203, []],
             [true,  300, []],
             [true,  301, []],

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -64,7 +64,8 @@ class UtilsTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test that responses are cache-able
+     * Test that responses are cache-able.
+     * 
      * @dataProvider exampleResponses
      */
     public function testCanCacheResponse($canCache, $statusCode, $headers)


### PR DESCRIPTION
HTTP 308 is redirect permanent, so it should be cache-able
https://en.wikipedia.org/wiki/List_of_HTTP_status_codes

Allows also to cache 206 partial content responses (replaces https://github.com/guzzle/cache-subscriber/pull/67)

404 responses should be cacheable
