### PR TITLE
Allow responses with content range to be cached

### DIFF
--- a/src/Utils.php
+++ b/src/Utils.php
@@ -152,11 +152,6 @@ class Utils
             return false;
         }
 
-        // Don't fool with Content-Range requests for now
-        if ($response->hasHeader('Content-Range')) {
-            return false;
-        }
-
         $freshness = self::getFreshness($response);
 
         return $freshness === null                    // No freshness info.


### PR DESCRIPTION
If a response has support ranges, then Vary should contain the "range" keyword