### PR TITLE
Allow to purge cache with different variants

### DIFF
--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -145,7 +145,7 @@ class CacheStorage implements CacheStorageInterface
 
         // Delete any cached Vary header responses.
         foreach (['GET', 'HEAD', 'POST', 'PUT', 'DELETE', 'OPTIONS', 'PURGE'] as $m) {
-            $this->deleteVary(new Request($url, $m));
+            $this->deleteVary(new Request($m, $url));
         }
     }
 


### PR DESCRIPTION
This solves a problem of purging caches with different variants.

```
GET /foo
Language: en
...
200 OK
Cache-Control: max-age=600
Vary: Language
response body


GET /foo
Language: fr
...
200 OK
Cache-Control: max-age=600
Vary: Language
a different response body
```

This gets properly cached. 

Now let's try to purge the cache: 

```
PURGE /foo
```

Does not invalidate the cache, since is not able to reproduce the "language" header that is used to build the key.

This PR solves this bug.
