### PR TITLE
Fix vary related stuff

### DIFF
--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -312,7 +312,7 @@ class CacheStorage implements CacheStorageInterface
                 continue;
             }
 
-            $varyCmp = isset($entry[1]['vary']) ? $entries[1]['vary'] : '';
+            $varyCmp = isset($entry[1]['vary']) ? $entry[1]['vary'] : '';
 
             if ($vary != $varyCmp ||
                 !$this->requestsMatch($vary, $entry[0], $persistedRequest)

--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -135,7 +135,7 @@ class CacheStorage implements CacheStorageInterface
         $entries = unserialize($entries);
 
         foreach ($entries as $index => $entry) {
-            $vary = isset($entry[1]['vary']) ? $entry[1]['vary'] : '';
+            $vary = isset($entry[1]['Vary']) ? $entry[1]['Vary'] : (isset($entry[1]['vary']) ? $entry[1]['vary'] : '');
             if ($this->requestsMatch($vary, $headers, $entry[0])) {
                 $match = $entry;
                 $matchIndex = $index;
@@ -312,7 +312,7 @@ class CacheStorage implements CacheStorageInterface
                 continue;
             }
 
-            $varyCmp = isset($entry[1]['vary']) ? $entry[1]['vary'] : '';
+            $varyCmp = isset($entry[1]['Vary']) ? $entry[1]['Vary'] : (isset($entry[1]['vary']) ? $entry[1]['vary'] : '');
 
             if ($vary != $varyCmp ||
                 !$this->requestsMatch($vary, $entry[0], $persistedRequest)
@@ -354,7 +354,7 @@ class CacheStorage implements CacheStorageInterface
         ResponseInterface $response
     ) {
         $key = $this->getVaryKey($request);
-        $this->cache->save($key, $this->normalizeVary($response), $this->getTtl($response));
+        $this->cache->save($key, serialize($this->normalizeVary($response)), $this->getTtl($response));
     }
 
     /**
@@ -371,7 +371,7 @@ class CacheStorage implements CacheStorageInterface
     private function fetchVary(RequestInterface $request)
     {
         $key = $this->getVaryKey($request);
-        $varyHeaders = $this->cache->fetch($key);
+        $varyHeaders = unserialize($this->cache->fetch($key));
 
         return is_array($varyHeaders) ? $varyHeaders : [];
     }


### PR DESCRIPTION
This PR addresses 3 issues:

1) There is a typo mistake in getManifestEntries method. 
2) As said in issue #52 The vary header is saved uppercase, and it won't match in https://github.com/guzzle/cache-subscriber/blob/master/src/CacheStorage.php#L138. @alcohol said that Guzzle keeps the headers in lowercase, that is true, internally, the variable is called: $headerNames ([see here](https://github.com/guzzle/guzzle/blob/5.3/src/Message/AbstractMessage.php#L12) and [here](https://github.com/guzzle/guzzle/blob/5.3/src/Message/AbstractMessage.php#L84))
3) The data is saved as an array but the rest of the data is always saved as string. I think serializing it is the best to be more compatible across adapters. This way it works flawlessly with zf2 filesystem cache adapter. 
