### PR TITLE
Improvement on condition checking for canCache

### DIFF
--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -312,7 +312,7 @@ class CacheStorage implements CacheStorageInterface
                 continue;
             }
 
-            $varyCmp = isset($entry[1]['vary']) ? $entries[1]['vary'] : '';
+            $varyCmp = isset($entry[1]['vary']) ? $entry[1]['vary'] : '';
 
             if ($vary != $varyCmp ||
                 !$this->requestsMatch($vary, $entry[0], $persistedRequest)

--- a/src/CacheStorage.php
+++ b/src/CacheStorage.php
@@ -135,7 +135,7 @@ class CacheStorage implements CacheStorageInterface
         $entries = unserialize($entries);
 
         foreach ($entries as $index => $entry) {
-            $vary = isset($entry[1]['vary']) ? $entry[1]['vary'] : '';
+            $vary = isset($entry[1]['Vary']) ? $entry[1]['Vary'] : (isset($entry[1]['vary']) ? $entry[1]['vary'] : '');
             if ($this->requestsMatch($vary, $headers, $entry[0])) {
                 $match = $entry;
                 $matchIndex = $index;
@@ -312,7 +312,7 @@ class CacheStorage implements CacheStorageInterface
                 continue;
             }
 
-            $varyCmp = isset($entry[1]['vary']) ? $entry[1]['vary'] : '';
+            $varyCmp = isset($entry[1]['Vary']) ? $entry[1]['Vary'] : (isset($entry[1]['vary']) ? $entry[1]['vary'] : '');
 
             if ($vary != $varyCmp ||
                 !$this->requestsMatch($vary, $entry[0], $persistedRequest)
@@ -354,7 +354,7 @@ class CacheStorage implements CacheStorageInterface
         ResponseInterface $response
     ) {
         $key = $this->getVaryKey($request);
-        $this->cache->save($key, $this->normalizeVary($response), $this->getTtl($response));
+        $this->cache->save($key, serialize($this->normalizeVary($response)), $this->getTtl($response));
     }
 
     /**
@@ -371,7 +371,7 @@ class CacheStorage implements CacheStorageInterface
     private function fetchVary(RequestInterface $request)
     {
         $key = $this->getVaryKey($request);
-        $varyHeaders = $this->cache->fetch($key);
+        $varyHeaders = unserialize($this->cache->fetch($key));
 
         return is_array($varyHeaders) ? $varyHeaders : [];
     }

--- a/src/CacheSubscriber.php
+++ b/src/CacheSubscriber.php
@@ -161,8 +161,8 @@ class CacheSubscriber implements SubscriberInterface
 
         // Cache the response if it can be cached and isn't already
         if ($request->getConfig()->get('cache_lookup') === 'MISS'
-            && call_user_func($this->canCache, $request)
             && Utils::canCacheResponse($response)
+            && call_user_func($this->canCache, $request)
         ) {
             // Store the date when the response was cached
             $response->setHeader('X-Guzzle-Cache-Date', gmdate('D, d M Y H:i:s T', time()));


### PR DESCRIPTION
I moved the condition of canCache onComplete event after the canCacheResponse check. The strategy to determine if it is needed to cache or not will usually be more "expensive" than canCacheResponse. So there is no need to execute it if canCacheResponse returns false.

This is my develop branch, which also includes the fix-vary branch. If #70 is accepted, you can merge this one directly. If #70 is rejected but you think this change is acceptable, let me know and I can re-open another PR.
